### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#Copy with Style Textmate bundle
+# Copy with Style Textmate bundle
 
 This bundle allows copying code from TextMate to Keynote with colors and style.
 No more screenshots!
 
-##Usage
+## Usage
 
 In Textmate select text press Cmd+Shift+C, then go to Keynote and paste with Cmd+V
 
-##Installation
+## Installation
 
     mkdir -p ~/Library/Application\ Support/TextMate/Bundles
     cd ~/Library/Application\ Support/TextMate/Bundles
@@ -15,7 +15,7 @@ In Textmate select text press Cmd+Shift+C, then go to Keynote and paste with Cmd
     
 In Textmate select Bundles->Bundle Editor->Reload Bundles
 
-##Credits
+## Credits
 
 Command code was adopted from example presented in Josh Goebel's [blog post]( http://blog.pastie.org/2008/06/textmate-to-key.html)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
